### PR TITLE
Fixing Admin account authcontext

### DIFF
--- a/src/Services/Contexts/ContractContext.js
+++ b/src/Services/Contexts/ContractContext.js
@@ -97,6 +97,10 @@ export const ContractContextProvider = ({children}) => {
         isRegistered: stakeholderDetails.role === "" ? false : true,
         isVerified: stakeholderDetails.isVerified
       }
+      const role = await contractState.mainContract.methods.getRole(authState.address).call();
+      if(role == "admin"){
+        stakeholderDetails.role = role;
+      }
       authDispatch(authStateStakeholder(stakeholderDetails));
     }
   }


### PR DESCRIPTION
#22

# Description

When logging in with the admin account address, the client could not fetch the role for the admin account address and hence was prompted to register.

Fixes #22 

## Type of change

Please delete options that are not relevant.

- [ ] Updated UI/UX
- [X] Improved the business logic of code
- [ ] Added new feature
- [ ] Other

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
